### PR TITLE
Update WSL2 guide for current MonkeyOCRv2 main and vLLM

### DIFF
--- a/docs/wsl_support.md
+++ b/docs/wsl_support.md
@@ -1,0 +1,305 @@
+# MonkeyOCRv2 on WSL2 (Windows Subsystem for Linux)
+
+This guide covers running MonkeyOCRv2 Document Parsing on **WSL2 with an NVIDIA GPU**. If you are looking for native Windows support (without WSL), please refer to [MonkeyOCR Windows Support](https://github.com/Yuliang-Liu/MonkeyOCR/blob/main/docs/windows_support.md).
+
+## Tested Environment
+
+| Component | Version / Detail |
+|---|---|
+| **OS** | Windows 11 Home China (Build 26200) + WSL2 (Ubuntu) |
+| **GPU** | NVIDIA GeForce RTX 4060 Laptop GPU (8GB VRAM) |
+| **NVIDIA Driver** | 581.57 (CUDA 13.0 driver-level support) |
+| **CUDA Runtime** | **12.9** |
+| **Python** | 3.11.16 |
+| **PyTorch** | 2.11.0+cu129 |
+| **vLLM** | 0.25.1 |
+| **Model** | MonkeyOCRv2-S-Parsing (0.6B params, ~1.5GB weights, used for WSL2 validation) |
+
+---
+
+## Prerequisites
+
+### 1. WSL2 with GPU passthrough
+
+```powershell
+# In Windows PowerShell (Admin)
+wsl --install -d Ubuntu
+wsl --update
+```
+
+Ensure your NVIDIA driver supports WSL2 GPU. The driver from [nvidia.com/drivers](https://www.nvidia.com/download/index.aspx) includes WSL2 CUDA support. Verify inside WSL:
+
+```bash
+nvidia-smi
+```
+
+You should see your GPU listed with driver version and CUDA version.
+
+### 2. Install uv (Python package manager)
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source ~/.local/bin/env
+uv --version  # should show uv 0.11.x or later
+```
+
+---
+
+## Setup MonkeyOCRv2-Parsing
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/Yuliang-Liu/MonkeyOCRv2.git
+cd MonkeyOCRv2
+```
+
+### 2. Create virtual environment
+
+```bash
+uv venv --python 3.11
+source .venv/bin/activate
+```
+
+### 3. Install vLLM with CUDA 12.9
+
+With Tsinghua mirror (recommended for users in China):
+
+```bash
+uv pip install vllm \
+  --extra-index-url https://wheels.vllm.ai/0.25.1/cu129 \
+  --extra-index-url https://download.pytorch.org/whl/cu129 \
+  -i https://pypi.tuna.tsinghua.edu.cn/simple
+```
+
+### 4. Install dependencies
+
+```bash
+uv pip install timm==1.0.27 pypdfium2==5.10.1
+```
+
+### 5. Download model weights
+
+From ModelScope (faster in China):
+
+```bash
+uv pip install modelscope
+python download_model.py -t modelscope -n MonkeyOCRv2-S-Parsing
+```
+
+Or from HuggingFace:
+
+```bash
+python download_model.py -n MonkeyOCRv2-S-Parsing
+```
+
+---
+
+
+## Start vLLM Service
+
+```bash
+cd parsing
+VLLM_WSL2_ENABLE_PIN_MEMORY=1 \
+VLLM_USE_FLASHINFER_SAMPLER=0 \
+nohup python serve.py \
+  --model-path ../model_weight/MonkeyOCRv2-S-Parsing \
+  --gpu-memory-utilization 0.55 \
+  --max-model-len 8192 \
+  --max-num-batched-tokens 4096 \
+  --port 8888 \
+  -- --enforce-eager \
+  > ../vllm_serve.log 2>&1 &
+```
+
+Wait for the service to be ready:
+
+```bash
+# Check if port is listening
+ss -tlnp | grep 8888
+
+# Or check health endpoint
+curl -s http://127.0.0.1:8888/health
+```
+
+Check logs:
+
+```bash
+tail -f ../vllm_serve.log
+# Look for: "Resolved architecture: MonkeyOCRv2ForCausalLM"
+# And: "Starting vLLM API server 0 on http://0.0.0.0:8888"
+```
+
+Expected GPU memory usage after startup: **~4.5 GB** (for S-Parsing, 0.55 utilization, 8192 context).
+
+---
+
+## Test Inference
+
+### CLI test
+
+```bash
+cd parsing
+python parse.py \
+  -i ../images_test \
+  -m ../model_weight/MonkeyOCRv2-S-Parsing \
+  -o output/test \
+  -s http://127.0.0.1:8888 \
+  --skip-preprocess
+```
+
+### OpenAI-compatible API test
+
+```python
+import base64, io, requests
+from PIL import Image
+
+# Encode image
+with Image.open("document.jpg") as img:
+    img = img.convert("RGB")
+    # Resize to ~1M pixels
+    w, h = img.size
+    max_px = 1003520
+    if w * h > max_px:
+        scale = (max_px / (w * h)) ** 0.5
+        img = img.resize((max(1, int(w*scale)), max(1, int(h*scale))), Image.Resampling.LANCZOS)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    data_uri = "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+# Send request
+resp = requests.post("http://127.0.0.1:8888/v1/chat/completions", json={
+    "model": "MonkeyOCRv2",
+    "temperature": 0,
+    "max_tokens": 4096,
+    "messages": [{"role": "user", "content": [
+        {"type": "image_url", "image_url": {"url": data_uri}},
+        {"type": "text", "text": "Please output the text content from the image."}
+    ]}]
+})
+
+print(resp.json()["choices"][0]["message"]["content"])
+```
+
+---
+
+## Performance Benchmarks (RTX 5070 Laptop, eager mode)
+
+The following benchmark results were collected in the original WSL2 test environment on an RTX 5070 Laptop GPU and were not re-benchmarked with the updated vLLM 0.25.1 setup.
+
+Tested on 4 real-world document pages × 4 image pre-processing views (16 runs total), all with `max_tokens=4096`:
+
+| Page | Original | CLAHE | Shadow Norm | Unsharp | Avg |
+|---|---|---|---|---|---|
+| Arabic newspaper (outdoor) | 210.3s | 66.0s | 62.7s | 61.9s | 100.2s |
+| Arabic newspaper (indoor) | 144.2s | 67.4s | 62.2s | 63.7s | 84.4s |
+| Japanese newspaper | 79.4s | 63.5s | 62.3s | 62.1s | 66.8s |
+| Russian note | 46.1s | 45.8s | 48.8s | 46.0s | 46.7s |
+| **Average** | **120.0s** | **60.7s** | **59.0s** | **58.4s** | |
+
+> **Notes:**
+> - All runs with `temperature=0`, `max_tokens=4096`, eager mode (no Triton JIT)
+> - "Original" first-run times include cold-start overhead (~1-2 min for encoder warmup). Subsequent runs are ~45-65s.
+> - With `build-essential` installed, compiled mode can reduce latency by ~15-25%.
+> - GPU memory usage stable at ~4.5-4.8 GB throughout all runs.
+
+### Quick benchmark command
+
+```bash
+cd parsing
+PYTHONPATH=$(pwd) python -c "
+import time, requests, base64, io
+from PIL import Image
+
+img = Image.open('../images_test/sample.png').convert('RGB')
+w, h = img.size
+scale = (1003520 / (w * h)) ** 0.5
+img = img.resize((max(1, int(w*scale)), max(1, int(h*scale))), Image.Resampling.LANCZOS)
+buf = io.BytesIO()
+img.save(buf, format='PNG')
+data_uri = 'data:image/png;base64,' + base64.b64encode(buf.getvalue()).decode()
+
+t0 = time.perf_counter()
+r = requests.post('http://127.0.0.1:8888/v1/chat/completions', json={
+    'model': 'MonkeyOCRv2', 'temperature': 0, 'max_tokens': 4096,
+    'messages': [{'role': 'user', 'content': [
+        {'type': 'image_url', 'image_url': {'url': data_uri}},
+        {'type': 'text', 'text': 'Please output the text content from the image.'}
+    ]}]
+})
+elapsed = time.perf_counter() - t0
+tokens = r.json()['usage']['completion_tokens']
+print(f'Elapsed: {elapsed:.1f}s, Tokens: {tokens}, Speed: {tokens/elapsed:.1f} tok/s')
+"
+```
+
+---
+
+## Common Issues
+
+### 1. Triton JIT compilation fails
+
+**Symptom:** Service exits during first inference with compilation errors.
+
+**Cause:** No C++ compiler installed in WSL2 Ubuntu.
+
+**Fix:** Either:
+```bash
+sudo apt install -y build-essential  # enables full compilation
+```
+Or use `--enforce-eager` flag (slower but no compiler needed).
+
+### 2. WSL2 network is very slow downloading packages
+
+**Fix:** Use Tsinghua mirror:
+```bash
+export UV_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
+```
+
+## Stopping the Service
+
+```bash
+# Find the process
+ps aux | grep "serve.py.*8888" | grep -v grep
+
+# Graceful stop
+kill <PID>
+
+# Force stop if needed
+kill -9 <PID>
+
+# Verify GPU memory is freed
+nvidia-smi
+```
+
+---
+
+## File Structure After Setup
+
+```
+MonkeyOCRv2/
+├── docs/
+│   └── wsl_support.md          # This guide
+├── model_weight/
+│   └── MonkeyOCRv2-S-Parsing/
+│       ├── config.json
+│       ├── configuration_monkeyocrv2.py
+│       ├── model.safetensors   # ~1.5GB
+│       └── ...
+├── parsing/
+│   ├── serve.py                # vLLM serve entry point
+│   ├── modeling/
+│   │   └── modeling_monkeyocrv2_vllm.py  # Custom vLLM model registration
+│   └── ...
+├── .venv/                      # Python virtual environment
+└── vllm_serve.log              # Service log
+```
+
+---
+
+## References
+
+- [MonkeyOCRv2 Official Repository](https://github.com/Yuliang-Liu/MonkeyOCRv2)
+- [MonkeyOCR Windows Support](https://github.com/Yuliang-Liu/MonkeyOCR/blob/main/docs/windows_support.md) — native Windows setup (non-WSL)
+- [vLLM Installation Guide](https://docs.vllm.ai/en/stable/getting_started/installation/gpu/)
+- [NVIDIA CUDA on WSL](https://docs.nvidia.com/cuda/wsl-user-guide/index.html)


### PR DESCRIPTION
## Summary

Update the WSL2 setup guide to work with the current MonkeyOCRv2 `main` branch while keeping the original PR #11 workflow as unchanged as possible.

The previous guide used vLLM 0.11.2, while the current MonkeyOCRv2 vLLM adapter uses newer `vllm.v1` APIs. This caused `ModuleNotFoundError` when following the old setup with the latest `main`.

## Changes

- Update Python from 3.10 to 3.11.
- Update the vLLM installation to the current vLLM 0.25.1 / CUDA 12.9 setup.
- Remove the old vLLM 0.11.2 compatibility workarounds (`AutoModel`, `text_config`, and manual model registration setup).
- Add the WSL2 runtime settings required by the current vLLM V2 model runner:
  - `VLLM_WSL2_ENABLE_PIN_MEMORY=1`
  - `VLLM_USE_FLASHINFER_SAMPLER=0`
- Update the inference example and remove obsolete vLLM 0.11.2 references.
- Keep the original benchmark results, clearly marking them as results from the original RTX 5070 test environment.

## Validation

Validated on:

- Windows 11 + WSL2 Ubuntu
- NVIDIA GeForce RTX 4060 Laptop GPU (8 GB)
- Python 3.11.16
- PyTorch 2.11.0+cu129
- vLLM 0.25.1
- MonkeyOCRv2-S-Parsing

Verified successfully:

- current `modeling_monkeyocrv2_vllm.py` imports with vLLM 0.25.1
- vLLM service startup
- `/health` and API access
- end-to-end `parse.py` inference

`MonkeyOCRv2-S-Parsing` was used only for WSL2 validation on the 8 GB GPU.