### PR TITLE
Fix BackendConfig validation and add Python syntax CI

### DIFF
--- a/.github/workflows/python-syntax.yml
+++ b/.github/workflows/python-syntax.yml
@@ -1,0 +1,34 @@
+name: Python syntax
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Parse every Python file with ast
+        run: |
+          python - <<'PY'
+          import ast
+          import sys
+          from pathlib import Path
+
+          paths = sorted(p for p in Path(".").rglob("*.py") if ".git" not in p.parts)
+          errors = []
+          for path in paths:
+              try:
+                  ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+              except SyntaxError as exc:
+                  errors.append(f"{path}:{exc.lineno}: {type(exc).__name__}: {exc.msg}")
+          print(f"Parsed {len(paths)} Python files; {len(errors)} syntax error(s)")
+          for line in errors:
+              print(line, file=sys.stderr)
+          sys.exit(1 if errors else 0)
+          PY

--- a/parsing/core_runner.py
+++ b/parsing/core_runner.py
@@ -1972,6 +1972,7 @@ class BackendConfig:
     preprocess_batch_size: int = 32
     skip_preprocess: bool = False
 
+    def __post_init__(self):
         if not str(self.server_url or "").strip():
             raise ValueError(
                 "server_url is required (set --server-url or MOCR2_SERVER_URL); local model inference is not supported. "


### PR DESCRIPTION
## Problem

On current `main` (3dbefb9e3cd4f53fc5560984ae7dbd7fcc8b0fd0), importing `parsing.core_runner` fails:

```text
  File "parsing/core_runner.py", line 1975
    if not str(self.server_url or "").strip():
IndentationError: unexpected indent
```

This breaks every GPU Parsing entry point that imports the runner: `parsing/parse.py`, the FastAPI app (`parsing/fastapi/main.py`), and the Gradio demo (`parsing/demo/gradio_demo.py`).

## Root cause

#27 added `server_url` validation to the frozen `BackendConfig` dataclass, but the `def __post_init__(self):` declaration line was lost, leaving the validation block indented directly in the class body.

## Change

1. Restore the `def __post_init__(self):` line (one line added; validation logic and error message unchanged).
2. Add a dependency-free GitHub Actions workflow that AST-parses every Python file on Python 3.11, so a syntax error cannot land on `main` again. It needs no GPU, no model weights, and installs nothing.

The two changes are separate commits — happy to drop the workflow commit or move it to its own PR if you prefer to keep this one minimal.

## Tests

- Baseline (before fix): AST parse of all 696 Python files reports exactly one syntax error, `parsing/core_runner.py:1975 IndentationError: unexpected indent`.
- After fix: `files=696 syntax_errors=0`.
- Behavior check of the restored validation (class executed standalone, no dependencies): a non-empty `server_url` is accepted; `""`, whitespace, and `None` raise the existing `ValueError`.
- `git diff --check` clean.

All three entry points pass a server URL from a required `--server-url` flag (or `MOCR2_SERVER_URL` for FastAPI), so restoring the validation only makes misconfigured setups fail fast with the message added in #27.

## Compatibility / Risk

No runtime API change. `BackendConfig` fields, defaults, and the error message are untouched. The workflow runs on `pull_request` and pushes to `main` only.

## Non-goals

No changes to vLLM serving, the CPU runner, output formats, dependencies, or any vendored code (`parsing/train/ms-swift`, `detection/DPText-DETR`).

## Question for maintainers

Should empty-`server_url` validation stay in the dataclass long-term, or would you rather have each CLI/config layer own it? This PR only restores the behavior #27 clearly intended, without deciding that.
