### PR TITLE
Fix leftover CPU-guide links after #34

### DIFF
--- a/docs/cpu_support.md
+++ b/docs/cpu_support.md
@@ -1,8 +1,8 @@
 # MonkeyOCRv2-Parsing on CPU 
 
-This guide covers running MonkeyOCRv2 Document Parsing on **CPU**. If you are looking for support for GPU, please refer to [MonkeyOCRv2](https://github.com/Yuliang-Liu/MonkeyOCR/blob/main/README.md).
+This guide covers running MonkeyOCRv2 Document Parsing on **CPU**. For GPU inference, see [Document Parsing](../README.md#document-parsing) in this repository.
 
-CPU inference loads only the parsing checkpoint passed to `-m` / `--model-path` (`MonkeyOCRv2-B-Parsing` or `MonkeyOCRv2-S-Parsing`). Do **not** download `MonkeyOCRv2-B-Parsing-DFlash` for this guide: that draft model is used only for GPU vLLM speculative decoding. See [Document Parsing](../README.md#document-parsing) if you need DFlash. Subproject version pins are summarized in the [version compatibility matrix](version_matrix.md).
+CPU inference loads only the parsing checkpoint passed to `-m` / `--model-path` (`MonkeyOCRv2-B-Parsing` or `MonkeyOCRv2-S-Parsing`). Do **not** download `MonkeyOCRv2-B-Parsing-DFlash` for this guide: that draft model is used only for GPU vLLM speculative decoding.
 
 ---
 


### PR DESCRIPTION
## Problem

#34 removed `docs/version_matrix.md` and the DFlash download commands, but two leftover sentences in `docs/cpu_support.md` still:

1. Link GPU readers to [MonkeyOCR v1](https://github.com/Yuliang-Liu/MonkeyOCR) instead of this repository.
2. Point at `version_matrix.md`, which no longer exists.

## Change

- GPU sentence now links to [Document Parsing](../README.md#document-parsing) in this repo.
- Drop the `version_matrix.md` sentence. The DFlash warning stays.

## Tests

- `git diff --stat` is only `docs/cpu_support.md` (2 lines changed)
- No code or install-script changes

Follow-up to https://github.com/Yuliang-Liu/MonkeyOCRv2/pull/34

Made with [Cursor](https://cursor.com)