### PR TITLE
Document Und vLLM trust_remote_code in the Hub-files note

### DIFF
--- a/docs/trust_remote_code.md
+++ b/docs/trust_remote_code.md
@@ -27,6 +27,7 @@ that SHA.
 | `understanding/infer.py` | `AutoModelForCausalLM`, `AutoProcessor` | S-Und, B-Und |
 | `parsing/cpu/core_runner.py` | `AutoModelForCausalLM`, `AutoProcessor` | S-Parsing, B-Parsing |
 | `parsing/serve.py` | vLLM `serve --trust-remote-code` | S-Parsing, B-Parsing, optional DFlash draft |
+| `understanding/serve.py` | vLLM `serve --trust-remote-code` | S-Und, B-Und |
 
 Recognition and detection training load the encoder checkpoints the same way
 (`trust_remote_code=True` on `AutoModel`).
@@ -35,6 +36,14 @@ Recognition and detection training load the encoder checkpoints the same way
 and registers `MonkeyOCRv2ForCausalLM` with vLLM. It still passes
 `--trust-remote-code` so Hugging Face can load the snapshot's custom config and
 processor modules.
+
+`understanding/serve.py` first imports this GitHub repo's
+`understanding/modeling/` adapters: vLLM 0.11.x loads
+`modeling_monkeyocrv2und_vllm_011.py`, and vLLM ≥ 0.25 loads
+`modeling_monkeyocrv2und_vllm.py`. It still passes `--trust-remote-code` so
+Hugging Face can load the Und snapshot's custom config and processor modules
+(listed under Document understanding below). Those local adapters are not the
+`.py` files that ship in the Hugging Face snapshot.
 
 ## Custom Python files
 


### PR DESCRIPTION
## Problem

#40 added `understanding/serve.py`, which appends `--trust-remote-code` and
imports this repo's `understanding/modeling/modeling_monkeyocrv2und_vllm*.py`.
`docs/trust_remote_code.md` (from #36) still only listed `parsing/serve.py`.

## Change

Docs only: add the Und serve call site to the table and a short paragraph
mirroring the existing Parsing serve note. Hub Und `.py` SHA tables are
unchanged.

## Tests

- `git diff --stat` is only `docs/trust_remote_code.md`
- Cross-checked against `understanding/serve.py` on current main

## Non-goals

- No Transformers-native registration
- No Hub SHA refresh
- No Python changes
