### PR TITLE
Run FastAPI parse-zip tests in CI

### DIFF
--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - "parsing/core_runner.py"
       - "parsing/tests/**"
+      - "parsing/fastapi/**"
       - ".github/workflows/parsing-tests.yml"
   pull_request:
     paths:
       - "parsing/core_runner.py"
       - "parsing/tests/**"
+      - "parsing/fastapi/**"
       - ".github/workflows/parsing-tests.yml"
 
 jobs:
@@ -23,6 +25,8 @@ jobs:
           python-version: "3.11"
           cache: pip
       - name: Install test dependencies
-        run: python -m pip install pytest pillow requests
+        run: python -m pip install pytest pillow requests fastapi python-multipart aiofiles
       - name: Run parsing regression tests
         run: python -m pytest parsing/tests -q
+      - name: Run FastAPI parse-zip contract tests
+        run: python -m pytest parsing/fastapi/test_parse_api.py -q

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ encoder = AutoModel.from_pretrained(
 See the Vision Encoder [Quick Start](https://github.com/Yuliang-Liu/MonkeyOCRv2#vision-encoder) for installation and feature-extraction examples. If you adapt MonkeyOCRv2 to a new task or domain, feel free to open an issue or pull request and share the results.
 
 ## MonkeyDoc v2
-MonkeyDoc v2 is currently the largest document image pre-training image-text pair dataset, comprising 113 million document images across 17 languages. The open-sourcing of MonkeyDoc v2 is still underway. So far, we have released 52 million synthetic samples and 41 million real-world samples. You can download the full datset as follows:
+MonkeyDoc v2 is currently the largest document image pre-training image-text pair dataset, comprising 113 million document images across 17 languages. The open-sourcing of MonkeyDoc v2 is still underway. So far, we have released 52 million synthetic samples and 41 million real-world samples. You can download the full dataset as follows:
 ```bash
 pip install modelscope
 modelscope download --dataset zenosai/MonkeyDocv2 --local_dir ./MonkeyDocv2
@@ -337,6 +337,8 @@ python fastapi/main.py -s http://127.0.0.1:8888 -p 8000
 python fastapi/main.py -h
 ```
 You can access the API documentation at http://localhost:8000/docs to explore available endpoints.
+
+`POST /parse` accepts a single multipart field `file` or a repeatable `files` field and returns `application/zip` (`monkeyocrv2_results.zip`), with one directory per document containing Markdown. See `/docs` for the remaining endpoints and request fields.
 
 #### 5. Fine-tune
 You can fine-tune MonkeyOCRv2-Parsing on your own data. Please refer to the [training instructions](parsing/train/README.md).

--- a/parsing/fastapi/conftest.py
+++ b/parsing/fastapi/conftest.py
@@ -1,0 +1,27 @@
+"""Collect FastAPI contract tests without torch, GPU, or model weights.
+
+``test_parse_api.py`` imports ``main``, which imports ``core_runner``. Reuse the
+torch / preprocessor stubs from ``parsing/tests/conftest.py`` instead of copying
+that suite, and put this directory on ``sys.path`` so ``import main`` works from
+the repository root.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+FASTAPI_DIR = Path(__file__).resolve().parent
+_TESTS_CONFTEST = FASTAPI_DIR.parent / "tests" / "conftest.py"
+
+_spec = importlib.util.spec_from_file_location("_parsing_tests_stubs", _TESTS_CONFTEST)
+if _spec is None or _spec.loader is None:
+    raise ImportError(f"Could not load stub helpers from {_TESTS_CONFTEST}")
+_stubs = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_stubs)
+_stubs._install_torch_stub_if_missing()
+_stubs._install_preprocessor_stub()
+
+if str(FASTAPI_DIR) not in sys.path:
+    sys.path.insert(0, str(FASTAPI_DIR))


### PR DESCRIPTION
## Problem

#39 added `parsing/fastapi/test_parse_api.py` (fake pipeline, no weights) and
a multi-file `/parse` ZIP response. `.github/workflows/parsing-tests.yml`
neither installs FastAPI deps nor pytest's that directory, so the new tests
never run on GitHub. README 4.3 still only says "see /docs".

## Change

- Extend the existing parsing-tests workflow to collect and run the FastAPI
  contract tests without GPU or checkpoints.
- Add `parsing/fastapi/conftest.py` so `import main` reuses the torch /
  preprocessor stubs from `parsing/tests/conftest.py`.
- Keep the current `parsing/tests` job/command.
- Document `POST /parse` `file` / `files` → `application/zip` in README 4.3.
- One-word README typo: `datset` → `dataset`.

## Tests

```
pytest parsing/tests -q
pytest parsing/fastapi/test_parse_api.py -q
```

## Non-goals

- No change to parse pipeline behavior
- No vLLM / model download
- No RAGFlow integration
