### PR TITLE
Test parsing vLLM argv without importing vLLM

### DIFF
--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -5,12 +5,16 @@ on:
     branches: [main]
     paths:
       - "parsing/core_runner.py"
+      - "parsing/serve.py"
+      - "parsing/vllm_argv.py"
       - "parsing/tests/**"
       - "parsing/fastapi/**"
       - ".github/workflows/parsing-tests.yml"
   pull_request:
     paths:
       - "parsing/core_runner.py"
+      - "parsing/serve.py"
+      - "parsing/vllm_argv.py"
       - "parsing/tests/**"
       - "parsing/fastapi/**"
       - ".github/workflows/parsing-tests.yml"

--- a/parsing/serve.py
+++ b/parsing/serve.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import json
 import os
 import re
 import socket
@@ -10,6 +9,7 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 from vllm.entrypoints.cli.main import main as vllm_main
+from vllm_argv import build_vllm_argv
 
 
 PARSING_DIR = Path(__file__).resolve().parent
@@ -40,49 +40,6 @@ def ensure_model_path(model_path: str):
     path = Path(model_path).expanduser()
     if not path.exists():
         raise SystemExit(f"Model path does not exist: {path}")
-
-
-def build_vllm_argv(args) -> list[str]:
-    """Build the vLLM command and add DFlash only when a draft is supplied."""
-    argv = [
-        "vllm",
-        "serve",
-        args.model_path,
-        "--tensor-parallel-size",
-        str(args.tensor_parallel_size),
-        "--gpu-memory-utilization",
-        str(args.gpu_memory_utilization),
-        "--max-model-len",
-        str(args.max_model_len),
-        "--max-num-batched-tokens",
-        str(args.max_num_batched_tokens),
-        "--served-model-name",
-        args.served_model_name,
-        "--port",
-        str(args.port),
-    ]
-    if args.max_num_seqs:
-        argv.extend(["--max-num-seqs", str(args.max_num_seqs)])
-    if args.host:
-        argv.extend(["--host", args.host])
-
-    if args.target_attention_backend:
-        argv.extend(["--attention-backend", args.target_attention_backend])
-
-    if args.draft_model:
-        draft_model = str(Path(args.draft_model).expanduser())
-        ensure_model_path(draft_model)
-        speculative_config = {
-            "method": "dflash",
-            "model": draft_model,
-            "num_speculative_tokens": args.dflash_num_speculative_tokens,
-        }
-        if args.dflash_attention_backend:
-            speculative_config["attention_backend"] = args.dflash_attention_backend
-        argv.extend(["--speculative-config", json.dumps(speculative_config)])
-
-    argv.append("--trust-remote-code")
-    return argv
 
 
 def ensure_port_available(host: str | None, port: int):

--- a/parsing/tests/test_vllm_argv.py
+++ b/parsing/tests/test_vllm_argv.py
@@ -1,0 +1,85 @@
+"""Cover ``build_vllm_argv`` without importing vLLM or touching weights."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from vllm_argv import build_vllm_argv
+
+
+def _args(**overrides):
+    values = dict(
+        model_path="/models/MonkeyOCRv2-B-Parsing",
+        tensor_parallel_size=1,
+        gpu_memory_utilization=0.5,
+        max_model_len=16384,
+        max_num_batched_tokens=16384,
+        served_model_name="MonkeyOCRv2",
+        port=8888,
+        max_num_seqs=128,
+        host=None,
+        target_attention_backend=None,
+        draft_model=None,
+        dflash_num_speculative_tokens=16,
+        dflash_attention_backend=None,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_importing_vllm_argv_does_not_load_vllm():
+    assert not any(name == "vllm" or name.startswith("vllm.") for name in sys.modules)
+
+
+def test_no_draft_omits_speculative_config():
+    argv = build_vllm_argv(_args())
+    assert argv[0] == "vllm"
+    assert argv[1] == "serve"
+    assert argv[2] == "/models/MonkeyOCRv2-B-Parsing"
+    assert "--port" in argv
+    assert argv[argv.index("--port") + 1] == "8888"
+    assert "--trust-remote-code" in argv
+    assert "--speculative-config" not in argv
+    assert all("dflash" not in part for part in argv)
+
+
+def test_trust_remote_code_is_last():
+    argv = build_vllm_argv(_args())
+    assert argv[-1] == "--trust-remote-code"
+    argv = build_vllm_argv(_args(draft_model="~/draft-weights", dflash_num_speculative_tokens=8))
+    assert argv[-1] == "--trust-remote-code"
+
+
+def test_draft_model_emits_dflash_speculative_config():
+    argv = build_vllm_argv(
+        _args(draft_model="~/draft-weights", dflash_num_speculative_tokens=8)
+    )
+    config = json.loads(argv[argv.index("--speculative-config") + 1])
+    assert config["method"] == "dflash"
+    assert config["model"] == str(Path("~/draft-weights").expanduser())
+    assert config["num_speculative_tokens"] == 8
+    assert "attention_backend" not in config
+
+
+def test_host_and_attention_backend_are_optional():
+    without = build_vllm_argv(_args())
+    assert "--host" not in without
+    assert "--attention-backend" not in without
+
+    with_both = build_vllm_argv(
+        _args(host="127.0.0.1", target_attention_backend="FLASH_ATTN")
+    )
+    assert with_both[with_both.index("--host") + 1] == "127.0.0.1"
+    assert with_both[with_both.index("--attention-backend") + 1] == "FLASH_ATTN"
+
+
+def test_falsy_max_num_seqs_omits_flag():
+    argv = build_vllm_argv(_args(max_num_seqs=0))
+    assert "--max-num-seqs" not in argv
+    argv = build_vllm_argv(_args(max_num_seqs=None))
+    assert "--max-num-seqs" not in argv
+    argv = build_vllm_argv(_args(max_num_seqs=128))
+    assert argv[argv.index("--max-num-seqs") + 1] == "128"

--- a/parsing/vllm_argv.py
+++ b/parsing/vllm_argv.py
@@ -1,0 +1,47 @@
+"""Assemble the ``vllm serve`` argv without importing vLLM."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def build_vllm_argv(args) -> list[str]:
+    """Build the vLLM command and add DFlash only when a draft is supplied."""
+    argv = [
+        "vllm",
+        "serve",
+        args.model_path,
+        "--tensor-parallel-size",
+        str(args.tensor_parallel_size),
+        "--gpu-memory-utilization",
+        str(args.gpu_memory_utilization),
+        "--max-model-len",
+        str(args.max_model_len),
+        "--max-num-batched-tokens",
+        str(args.max_num_batched_tokens),
+        "--served-model-name",
+        args.served_model_name,
+        "--port",
+        str(args.port),
+    ]
+    if args.max_num_seqs:
+        argv.extend(["--max-num-seqs", str(args.max_num_seqs)])
+    if args.host:
+        argv.extend(["--host", args.host])
+
+    if args.target_attention_backend:
+        argv.extend(["--attention-backend", args.target_attention_backend])
+
+    if args.draft_model:
+        draft_model = str(Path(args.draft_model).expanduser())
+        speculative_config = {
+            "method": "dflash",
+            "model": draft_model,
+            "num_speculative_tokens": args.dflash_num_speculative_tokens,
+        }
+        if args.dflash_attention_backend:
+            speculative_config["attention_backend"] = args.dflash_attention_backend
+        argv.extend(["--speculative-config", json.dumps(speculative_config)])
+
+    argv.append("--trust-remote-code")
+    return argv


### PR DESCRIPTION
## Problem

`parsing/serve.py` already builds the `vllm serve` argv in `build_vllm_argv`, including DFlash `speculative_config` when a draft is supplied and `--trust-remote-code` at the end. The module also imports vLLM at load time (`from vllm.entrypoints...` plus `vllm_version_tuple()`), so `parsing/tests` cannot import `serve.py` without vLLM installed. CI never covered argv assembly or the DFlash JSON.

## Change

- Move `build_vllm_argv` to `parsing/vllm_argv.py`, which does not import vLLM.
- `serve.py` now does `from vllm_argv import build_vllm_argv`. Top-level vLLM version gating, modeling registration, `vllm_main`, `ensure_dflash_support`, and the port check stay in `serve.py`.
- `build_vllm_argv` no longer calls `ensure_model_path`, so argv assembly is a pure function. Path existence is still checked in `main()` for both `--model-path` and `--draft-model`.
- Add `parsing/tests/test_vllm_argv.py` (SimpleNamespace args): no-draft argv, `--trust-remote-code` last, draft DFlash JSON (`method=dflash`, expanduser model path, `num_speculative_tokens`), optional `--host` / `--attention-backend`, and omitting `--max-num-seqs` when the value is falsy.
- Trigger `parsing-tests.yml` on `parsing/serve.py` and `parsing/vllm_argv.py`.

## Tests

```
uv venv /tmp/mocr-argv --python python3.13 --clear
uv pip install --python /tmp/mocr-argv/bin/python pytest pillow requests
/tmp/mocr-argv/bin/python -m pytest parsing/tests -q
```

51 passed. No vLLM install, no weights download.

## Non-goals

- No DFlash JSON field-name changes, default port stays 8888, no modeling-registration changes, CI still does not install vLLM, argparse is unchanged.
- Does not call `vllm_main()`. Does not touch understanding/serve or FastAPI.


Made with [Cursor](https://cursor.com)