### PR TITLE
Test Und vLLM argv without importing vLLM

### DIFF
--- a/.github/workflows/understanding-tests.yml
+++ b/.github/workflows/understanding-tests.yml
@@ -1,0 +1,30 @@
+name: Understanding tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "understanding/serve.py"
+      - "understanding/vllm_argv.py"
+      - "understanding/tests/**"
+      - ".github/workflows/understanding-tests.yml"
+  pull_request:
+    paths:
+      - "understanding/serve.py"
+      - "understanding/vllm_argv.py"
+      - "understanding/tests/**"
+      - ".github/workflows/understanding-tests.yml"
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install test dependencies
+        run: python -m pip install pytest
+      - name: Run understanding regression tests
+        run: python -m pytest understanding/tests -q

--- a/understanding/serve.py
+++ b/understanding/serve.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 from vllm.entrypoints.cli.main import main as vllm_main
 
+from vllm_argv import build_vllm_argv
+
 UNDERSTANDING_DIR = Path(__file__).resolve().parent
 os.environ["PYTHONPATH"] = str(UNDERSTANDING_DIR) + os.pathsep + os.environ.get("PYTHONPATH", "")
 
@@ -61,12 +63,8 @@ def main() -> None:
     if not model_path.exists():
         raise SystemExit(f"Model path does not exist: {model_path}")
     ensure_port_available(args.host, args.port)
-    argv = ["vllm", "serve", str(model_path), "--tensor-parallel-size", str(args.tensor_parallel_size),
-            "--gpu-memory-utilization", str(args.gpu_memory_utilization), "--max-model-len", str(args.max_model_len),
-            "--max-num-seqs", str(args.max_num_seqs), "--max-num-batched-tokens", str(args.max_num_batched_tokens),
-            "--served-model-name", args.served_model_name, "--port", str(args.port), "--trust-remote-code"]
-    if args.host:
-        argv += ["--host", args.host]
+    args.model_path = str(model_path)
+    argv = build_vllm_argv(args)
     if args.extra_args:
         argv.extend(args.extra_args[1:] if args.extra_args[0] == "--" else args.extra_args)
     print("Running:", " ".join(argv))

--- a/understanding/tests/test_vllm_argv.py
+++ b/understanding/tests/test_vllm_argv.py
@@ -1,0 +1,66 @@
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+UNDERSTANDING_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(UNDERSTANDING_DIR))
+
+from vllm_argv import build_vllm_argv  # noqa: E402
+
+
+def _args(**overrides) -> Namespace:
+    values = dict(
+        model_path="/tmp/MonkeyOCRv2-S-Und",
+        tensor_parallel_size=1,
+        gpu_memory_utilization=0.5,
+        max_model_len=8196,
+        max_num_seqs=128,
+        max_num_batched_tokens=16384,
+        served_model_name="MonkeyOCRv2",
+        host=None,
+        port=8889,
+    )
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def test_importing_vllm_argv_does_not_import_vllm() -> None:
+    assert "vllm" not in sys.modules
+
+
+def test_default_argv_includes_port_max_model_len_and_trust_remote_code() -> None:
+    argv = build_vllm_argv(_args())
+    assert argv[:3] == ["vllm", "serve", "/tmp/MonkeyOCRv2-S-Und"]
+    assert argv[argv.index("--port") + 1] == "8889"
+    assert argv[argv.index("--max-model-len") + 1] == "8196"
+    assert "--trust-remote-code" in argv
+    assert "--host" not in argv
+
+
+def test_default_argv_matches_serve_contract() -> None:
+    assert build_vllm_argv(_args()) == [
+        "vllm",
+        "serve",
+        "/tmp/MonkeyOCRv2-S-Und",
+        "--tensor-parallel-size",
+        "1",
+        "--gpu-memory-utilization",
+        "0.5",
+        "--max-model-len",
+        "8196",
+        "--max-num-seqs",
+        "128",
+        "--max-num-batched-tokens",
+        "16384",
+        "--served-model-name",
+        "MonkeyOCRv2",
+        "--port",
+        "8889",
+        "--trust-remote-code",
+    ]
+
+
+def test_host_is_appended_when_provided() -> None:
+    argv = build_vllm_argv(_args(host="127.0.0.1"))
+    assert argv[-2:] == ["--host", "127.0.0.1"]
+    assert "--trust-remote-code" in argv

--- a/understanding/vllm_argv.py
+++ b/understanding/vllm_argv.py
@@ -1,0 +1,30 @@
+"""Build the vLLM serve argv for MonkeyOCRv2 understanding.
+
+This module must not import vLLM so the command contract can be tested in CI.
+"""
+
+
+def build_vllm_argv(args) -> list[str]:
+    argv = [
+        "vllm",
+        "serve",
+        str(args.model_path),
+        "--tensor-parallel-size",
+        str(args.tensor_parallel_size),
+        "--gpu-memory-utilization",
+        str(args.gpu_memory_utilization),
+        "--max-model-len",
+        str(args.max_model_len),
+        "--max-num-seqs",
+        str(args.max_num_seqs),
+        "--max-num-batched-tokens",
+        str(args.max_num_batched_tokens),
+        "--served-model-name",
+        args.served_model_name,
+        "--port",
+        str(args.port),
+        "--trust-remote-code",
+    ]
+    if args.host:
+        argv += ["--host", args.host]
+    return argv


### PR DESCRIPTION
## Problem

#40 added `understanding/serve.py` and #41 documented that it passes `--trust-remote-code`, but there were no tests. Argv was inlined in `main()`, and the module imports vLLM at load time (worker processes may not run `main()`, so architecture registration stays on import). `parsing-tests.yml` does not run understanding, so `--trust-remote-code`, port `8889`, and `--max-model-len 8196` could regress without CI.

## Change

- Move argv assembly to `understanding/vllm_argv.py`, which does not import vLLM.
- `serve.py` `main()` now calls `build_vllm_argv`, then extends `extra_args`, prints, sets `sys.argv`, and calls `vllm_main()`.
- Top-level `_VLLM_VERSION` and modeling registration are unchanged.
- `model_path.exists()` stays in `main()`; `build_vllm_argv` is a pure function.
- Add `understanding/tests/test_vllm_argv.py`: default argv includes port `8889`, `--max-model-len 8196`, and `--trust-remote-code`; no `--host` unless `host` is set.
- Add `.github/workflows/understanding-tests.yml` (`pytest understanding/tests -q`, Python 3.11, pytest only).

## Tests

```
uv venv /tmp/mocr-und-argv --python python3.13 --clear
uv pip install --python /tmp/mocr-und-argv/bin/python pytest
/tmp/mocr-und-argv/bin/python -m pytest understanding/tests -q
```

4 passed. No vLLM/torch/FastAPI install, no Und weights download.

## Non-goals

- Does not change Und modeling adapters, default port `8889`, or `--max-model-len 8196`.
- Does not copy parsing DFlash into understanding.
- Does not call `vllm_main()` in tests. CI does not install vLLM.


Made with [Cursor](https://cursor.com)