### PR TITLE
fix: explicit UTF-8 encoding in forensics/setup.py open() calls

### DIFF
--- a/forensics/setup.py
+++ b/forensics/setup.py
@@ -18,7 +18,7 @@ version_file = 'mmseg/version.py'
 
 
 def get_version():
-    with open(version_file) as f:
+    with open(version_file, encoding='utf-8') as f:
         exec(compile(f.read(), version_file, 'exec'))
     return locals()['__version__']
 
@@ -74,7 +74,7 @@ def parse_requirements(fname='requirements.txt', with_version=True):
             yield info
 
     def parse_require_file(fpath):
-        with open(fpath) as f:
+        with open(fpath, encoding='utf-8') as f:
             for line in f.readlines():
                 line = line.strip()
                 if line and not line.startswith('#'):


### PR DESCRIPTION
## Problem

`forensics/setup.py` opens two files — the version module (`mmseg/version.py`)
and the requirements file — using `open()` without an explicit `encoding`
argument. On systems where the locale default is not UTF-8 (Windows in
particular, but also some minimal Linux containers), this can cause a
`UnicodeDecodeError` when the file contains any non-ASCII character, or
silently misread bytes.

Both files are part of the repository and are always UTF-8 text, so relying
on the platform default encoding is fragile for no benefit.

## Solution

Pass `encoding='utf-8'` explicitly to both `open()` calls:

- `forensics/setup.py:21` — `get_version()` reading `mmseg/version.py`
- `forensics/setup.py:77` — `parse_require_file()` reading `requirements.txt`

This is the same defensive style already used elsewhere in the repo (e.g.
`formula/cdm_local/` scripts that read JSON).

## Testing

- `python3 -m py_compile forensics/setup.py` passes.
- `python3 forensics/setup.py --version` style invocations are unchanged;
  the only behavioral change is the explicit encoding, which is a strict
  improvement on non-UTF-8 locales and a no-op where UTF-8 is already the
  default.
