### PR TITLE
fix: explicit UTF-8 encoding for JSON read/write in convert2cdm_format.py

### DIFF
--- a/formula/cdm_local/convert2cdm_format.py
+++ b/formula/cdm_local/convert2cdm_format.py
@@ -4,7 +4,7 @@ from tqdm import tqdm
 import argparse
 
 def change_data_format(input_json, output_json):
-    with open(input_json,'r') as f:    
+    with open(input_json, 'r', encoding='utf-8') as f:
         all_datas = json.load(f)
 
     data_list = []
@@ -21,7 +21,7 @@ def change_data_format(input_json, output_json):
             }
             data_list.append(new_item)
             
-    with open(output_json, "w") as f:
+    with open(output_json, "w", encoding='utf-8') as f:
         f.write(json.dumps(data_list, indent=2))
         
 


### PR DESCRIPTION
Hey! I noticed `formula/cdm_local/convert2cdm_format.py` opens JSON files for
reading and writing without specifying an encoding. Since JSON is defined to
be UTF-8 by the spec (RFC 8259), and the data this script processes contains
LaTeX formulas and non-ASCII text, relying on the platform default can cause
problems on Windows or in minimal containers where the locale isn't UTF-8.

The fix is straightforward — two one-line changes:

- Line 7: `open(input_json, 'r')` → `open(input_json, 'r', encoding='utf-8')`
- Line 24: `open(output_json, "w")` → `open(output_json, "w", encoding='utf-8')`

I also cleaned up the trailing whitespace on line 7 while I was there.

Verified with `python3 -m py_compile` — no syntax issues. The script's
behavior is identical on UTF-8 systems and strictly more correct everywhere
else. Thanks for maintaining this tool!
