### PR TITLE
fix: explicit UTF-8 encoding for JSONL/JSON I/O in evaluation.py

### DIFF
--- a/formula/cdm_local/evaluation.py
+++ b/formula/cdm_local/evaluation.py
@@ -99,7 +99,7 @@ def evaluation(data_root, user_id="test"):
         if not os.path.exists(os.path.join(gt_box_dir, 'bbox', basename+".jsonl")):
             gt_valid = False
         else:
-            with open(os.path.join(gt_box_dir, 'bbox', basename+".jsonl"), 'r') as f:
+            with open(os.path.join(gt_box_dir, 'bbox', basename+".jsonl"), 'r', encoding='utf-8') as f:
                 box_gt = []
                 for line in f:
                     info = json.loads(line)
@@ -113,7 +113,7 @@ def evaluation(data_root, user_id="test"):
         if not os.path.exists(os.path.join(pred_box_dir, 'bbox', basename+".jsonl")):
             pred_valid = False
         else:
-            with open(os.path.join(pred_box_dir, 'bbox', basename+".jsonl"), 'r') as f:
+            with open(os.path.join(pred_box_dir, 'bbox', basename+".jsonl"), 'r', encoding='utf-8') as f:
                 box_pred = []
                 for line in f:
                     info = json.loads(line)
@@ -238,7 +238,7 @@ def evaluation(data_root, user_id="test"):
         "details": metrics_per_img
     }
     metric_res_path = os.path.join(data_root, "metrics_res.json")
-    with open(metric_res_path, "w") as f:
+    with open(metric_res_path, "w", encoding='utf-8') as f:
         f.write(json.dumps(metrics_res, indent=2))
     return metrics_res, metric_res_path, match_vis_dir
 
@@ -254,7 +254,7 @@ if __name__ == '__main__':
     json_input, data_root, pool_num = args.input, args.output, args.pools
     temp_dir = os.path.join(data_root, "temp_dir")
     exp_name = os.path.basename(json_input).split('.')[0]
-    with open(json_input, "r") as f:
+    with open(json_input, "r", encoding='utf-8') as f:
         input_data = json.load(f)
     img_ids = []
     groundtruths = []


### PR DESCRIPTION
The evaluation script in `formula/cdm_local/evaluation.py` reads JSONL ground-truth
and prediction files, writes a metrics JSON, and reads an input JSON — all through
`open()` calls that rely on the platform's default encoding. Since JSONL and JSON
are UTF-8 by spec, and these files contain LaTeX bounding-box annotations that may
include non-ASCII symbols, the encoding should be stated explicitly to avoid
`UnicodeDecodeError` on non-UTF-8 locales (Windows, some CI containers).

Four call sites updated:

* `evaluation.py:102` — GT `.jsonl` reader
* `evaluation.py:116` — prediction `.jsonl` reader
* `evaluation.py:241` — `metrics_res.json` writer
* `evaluation.py:257` — input JSON reader

Each change adds `encoding='utf-8'` to the existing `open()` call. No behavioral
change on systems where UTF-8 is already the default. Verified with
`python3 -m py_compile formula/cdm_local/evaluation.py`.
