### PR TITLE
Finish dropping +cpu from the Linux CPU install pin

### DIFF
--- a/docs/cpu_support.md
+++ b/docs/cpu_support.md
@@ -100,7 +100,7 @@ conda activate MonkeyOCRv2Parsing_CPU
 ### 3. Install dependencies
 
 ```bash
-pip install torch==2.5.1+cpu torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cpu
+pip install torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cpu
 pip install -r parsing/requirements.txt
 pip install transformers==4.57.1 accelerate==1.11.0 huggingface_hub qwen_vl_utils opencv-python einops
 ```


### PR DESCRIPTION
## Problem
zenosai's b2838c3 removed `+cpu` from the Windows pip pin in docs/cpu_support.md. The Linux install block still has `torch==2.5.1+cpu` with the same cpu index URL.

## Change
Use `torch==2.5.1 torchvision==0.20.1` on Linux, matching Windows. The `--index-url` remains the cpu wheel index.

## Tests
Docs only. `git diff` is that one install line.

## Non-goals
Does not change the CPU runner, DFlash warning, Windows block, or README News.


Made with [Cursor](https://cursor.com)