### PR TITLE
Reject unknown hub types in download_model.py

### DIFF
--- a/download_model.py
+++ b/download_model.py
@@ -4,7 +4,7 @@ import os
 
 if __name__ == '__main__':
     parser = ArgumentParser()
-    parser.add_argument('--type', '-t', type=str, default="huggingface") # huggingface or modelscope
+    parser.add_argument('--type', '-t', type=str, default="huggingface", choices=['huggingface', 'modelscope'])
     parser.add_argument('--name', '-n', type=str, default="MonkeyOCRv2-B-Parsing") # MonkeyOCRv2-S-Parsing
     args = parser.parse_args()
     script_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Problem
`download_model.py` accepts any `--type`. An unknown value still mkdir's `model_weight/<name>` and exits 0, so Quick Start typos look like success.

## Change
`choices=['huggingface', 'modelscope']` on `--type`. Defaults unchanged.

## Tests
`python download_model.py -t foo` exits non-zero. No Hub download.

## Non-goals
No importable helpers, no new CI job, no News.

Made with [Cursor](https://cursor.com)