### PR TITLE
Stop the WSL guide from installing removed timm

### DIFF
--- a/docs/wsl_support.md
+++ b/docs/wsl_support.md
@@ -75,7 +75,7 @@ uv pip install vllm \
 ### 4. Install dependencies
 
 ```bash
-uv pip install timm==1.0.27 pypdfium2==5.10.1
+uv pip install -r parsing/requirements.txt
 ```
 
 ### 5. Download model weights


### PR DESCRIPTION
## Problem
`refactor: remove timm dependency` removed `timm` from `parsing/requirements.txt`. `docs/wsl_support.md` still runs `uv pip install timm==1.0.27 pypdfium2==5.10.1`.

## Change
Install `-r parsing/requirements.txt` in the WSL dependency step, matching the CPU guide.

## Tests
Docs only.

## Non-goals
Does not touch forensics/formula/recognition timm, preprocessor embeddings, or README News.


Made with [Cursor](https://cursor.com)