### PR TITLE
Lock FastAPI ZIP markdown and stem.json contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ python fastapi/main.py -h
 ```
 You can access the API documentation at http://localhost:8000/docs to explore available endpoints.
 
-`POST /parse` accepts a single multipart field `file` or a repeatable `files` field and returns `application/zip` (`monkeyocrv2_results.zip`), with one directory per document containing Markdown. See `/docs` for the remaining endpoints and request fields.
+`POST /parse` accepts a single multipart field `file` or a repeatable `files` field and returns `application/zip` (`monkeyocrv2_results.zip`), with one directory per document containing Markdown and one canonical `{stem}.json`. See `/docs` for the remaining endpoints and request fields.
 
 #### 5. Fine-tune
 You can fine-tune MonkeyOCRv2-Parsing on your own data. Please refer to the [training instructions](parsing/train/README.md).

--- a/parsing/fastapi/test_parse_api.py
+++ b/parsing/fastapi/test_parse_api.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from tempfile import SpooledTemporaryFile
 
 import pytest
-from fastapi import UploadFile
+from fastapi import HTTPException, UploadFile
 
 import main
 
@@ -20,6 +20,22 @@ def setup(tmp_path, monkeypatch):
     monkeypatch.setattr(main.settings, "output_dir", str(tmp_path))
     async def fake_run_document_pipeline(upload, **kwargs):
         return f"# Parsed {Path(upload.filename).stem}\n\nMonkeyOCRv2"
+    monkeypatch.setattr(main, "run_document_pipeline", fake_run_document_pipeline)
+    yield tmp_path
+
+
+@pytest.fixture()
+def json_artifacts(tmp_path, monkeypatch):
+    monkeypatch.setattr(main.settings, "output_dir", str(tmp_path))
+
+    async def fake_run_document_pipeline(upload, **kwargs):
+        markdown = f"# Parsed {Path(upload.filename).stem}\n\nMonkeyOCRv2"
+        artifacts = {
+            "jsons/notice.json": b'{"ok": true}',
+            "all_results.json": b"{}",
+        }
+        return markdown, {}, artifacts
+
     monkeypatch.setattr(main, "run_document_pipeline", fake_run_document_pipeline)
     yield tmp_path
 
@@ -44,3 +60,60 @@ def test_parse_multiple_files_returns_one_zip(setup):
     with zipfile.ZipFile(io.BytesIO(response.body)) as archive:
         assert "page1/page1.md" in archive.namelist()
         assert "page2/page2.md" in archive.namelist()
+
+
+def test_parse_zip_exposes_stem_json_not_pipeline_json_paths(json_artifacts):
+    response = asyncio.run(main.parse_document(file=upload("notice.png"), files=None, start_page_id=0, end_page_id=99999))
+    with zipfile.ZipFile(io.BytesIO(response.body)) as archive:
+        names = archive.namelist()
+        assert "notice/notice.md" in names
+        assert "notice/notice.json" in names
+        assert archive.read("notice/notice.json") == b'{"ok": true}'
+        assert "all_results.json" not in names
+        assert "notice/all_results.json" not in names
+        assert "notice/notice_content_list.json" not in names
+        assert "jsons/notice.json" not in names
+        assert "notice/jsons/notice.json" not in names
+        assert not any("/jsons/" in name or name.startswith("jsons/") for name in names)
+
+
+def test_parse_requires_file_or_files(setup):
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(main.parse_document(file=None, files=None, start_page_id=0, end_page_id=99999))
+    assert exc_info.value.status_code == 422
+    assert "file or files" in exc_info.value.detail
+
+
+def test_parse_empty_files_list_requires_a_file(setup):
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(main.parse_document(file=None, files=[], start_page_id=0, end_page_id=99999))
+    assert exc_info.value.status_code == 422
+
+
+def test_parse_rejects_equal_page_ids(setup):
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(main.parse_document(file=upload("notice.png"), files=None, start_page_id=5, end_page_id=5))
+    assert exc_info.value.status_code == 422
+    assert "page range" in exc_info.value.detail
+
+
+def test_parse_rejects_negative_start_page_id(setup):
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(main.parse_document(file=upload("notice.png"), files=None, start_page_id=-1, end_page_id=99999))
+    assert exc_info.value.status_code == 422
+
+
+def test_parse_duplicate_filenames_keep_both_zip_entries(setup):
+    response = asyncio.run(main.parse_document(
+        files=[upload("notice.png"), upload("notice.png")], file=None, start_page_id=0, end_page_id=99999
+    ))
+    with zipfile.ZipFile(io.BytesIO(response.body)) as archive:
+        names = archive.namelist()
+        assert "notice/notice.md" in names
+        assert "notice_2/notice_2.md" in names
+
+
+def test_health_check_reports_backend_and_status():
+    payload = asyncio.run(main.health_check())
+    assert payload["backend"] == "server"
+    assert payload["status"] in {"healthy", "initializing"}


### PR DESCRIPTION
## Problem
d46699f changed `/parse` ZIP contents to Markdown plus one canonical `{stem}.json` from `jsons/`. Tests and README 4.3 still only mentioned Markdown.

## Change
Contract tests for the new ZIP layout, empty-upload/page-range 422s, duplicate names, and `/health`. One README 4.3 sentence. No main.py behavior change.

## Tests
pytest parsing/tests and parsing/fastapi/test_parse_api.py without GPU or weights.

## Non-goals
Does not test /ocr/*, does not extract vLLM argv, does not change WSL or formula README.

Made with [Cursor](https://cursor.com)