### PR TITLE
Import copy in CDM evaluation.py

### DIFF
--- a/formula/cdm_local/evaluation.py
+++ b/formula/cdm_local/evaluation.py
@@ -6,6 +6,7 @@ import time
 import shutil
 import argparse
 import inspect
+import copy
 import numpy as np
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
## Problem
#60: `gen_token_order` in formula/cdm_local/evaluation.py calls `copy.deepcopy` without `import copy`. The helper is unused on the current path, so the NameError is dormant.

## Change
Add `import copy`. No other behavior change.

## Tests
`python3` ast.parse of that file.

## Non-goals
Does not enable gen_token_order, does not change formula README, does not expand CDM.


Made with [Cursor](https://cursor.com)